### PR TITLE
Disable diagnostic endpoint in Nix cache Action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,4 +11,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          diagnostic-endpoint: ""
       - run: nix build .


### PR DESCRIPTION
Hello 👋 

I watched your YouTube video where you were demonstrating how to build with Nix in GitHub Actions. You asked about how to disable the diagnostic endpoint the Nix cache action.

You're correct that the Nix cache Action doesn't appear to have the input parameters documented anywhere. However, you can use the log output from GitHub Workflows to get any Action's input parameters, like this:

![image](https://github.com/LGUG2Z/satounki/assets/5676771/dd4aaf1d-04b5-4d7f-b854-541267ff720f)

And, after adding `diagnostic-endpoint` to an empty string:
![image](https://github.com/LGUG2Z/satounki/assets/5676771/a43c705c-f367-42ed-88ad-8dcdab459805)

You can also get them from an Action's [`action.yml`](https://github.com/DeterminateSystems/magic-nix-cache-action/blob/eeabdb06718ac63a7021c6132129679a8e22d0c7/action.yml#L31-L33)

You can find a successful workflow run in my fork [here](https://github.com/tangowithfoxtrot/satounki/actions/runs/7857233850).

I hope this helps! Your video was very helpful for me as I try to learn more about Nix. Thanks!